### PR TITLE
추가기능 UI 선택 반복시 기본 화면으로 돌아오는 현상 해결

### DIFF
--- a/PLCSimulator/BaseForm.cs
+++ b/PLCSimulator/BaseForm.cs
@@ -144,7 +144,7 @@ namespace PLCSimulator
 
         private void button_Macro_Click(object sender, EventArgs e)
         {
-            if (m_macroUserControl.Visible)
+            if (m_macroUserControl.Visible && panel_tab.Controls[0] == m_macroUserControl)
                 HideAdditionalControl();
             else
             {
@@ -155,7 +155,7 @@ namespace PLCSimulator
 
         private void button_Sync_Click(object sender, EventArgs e)
         {
-            if (m_syncUserControl.Visible)
+            if (m_syncUserControl.Visible && panel_tab.Controls[0] == m_syncUserControl)
                 HideAdditionalControl();
             else
             {


### PR DESCRIPTION
추가기능 UI 선택 반복 시 (Macro - Sync - Macro 순 등) 해당 UI 뜨지 않고 기본 데이터 화면으로 돌아가는 현상 수정