### PR TITLE
Modbus Udp 서버 정상 종료되지 않던 문제 해결

### DIFF
--- a/PLCSimulator/Program.cs
+++ b/PLCSimulator/Program.cs
@@ -14,6 +14,7 @@ namespace PLCSimulator
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new BaseForm());
+            Environment.Exit(0);
         }
     }
 }


### PR DESCRIPTION
Dll 문제로 Udp 서버로 열 경우 정상적으로 종료되지 않아 프로그램 종료 시점에 강제 종료 키워드 추가