### PR TITLE
최대 데이터 수 설정 기능 추가

### DIFF
--- a/PLCSimulator/AppInstance.cs
+++ b/PLCSimulator/AppInstance.cs
@@ -26,6 +26,8 @@
 
         public void Start()
         {
+            var maxBitData = ProfileRecipe.Instance.ProfileInfo.MaxBitData;
+            var maxWordData = ProfileRecipe.Instance.ProfileInfo.MaxWordData;
             MacroManager = new MacroManager(DataManager.Instance, ProfileRecipe.Instance.ProfileInfo.MacroInfoArray);
             SyncManager = SyncManager.Instance;
 
@@ -36,23 +38,23 @@
             switch (selectedProtocol)
             {
                 case Protocol.MewtocolUdp:
-                    m_panasonicServer = new MewtocolServer(serverPort);
+                    m_panasonicServer = new MewtocolServer(serverPort, maxBitData, maxWordData);
                     m_panasonicServer.Start();
                     break;
 
                 case Protocol.MewtocolSerial:
-                    m_panasonicServer = new MewtocolServer(serverPortName);
+                    m_panasonicServer = new MewtocolServer(serverPortName, maxBitData, maxWordData);
                     m_panasonicServer.Start();
                     break;
 
                 case Protocol.UpperLinkUdp:
-                    m_omronServer = new UpperLinkServer(serverPort);
+                    m_omronServer = new UpperLinkServer(serverPort, maxBitData, maxWordData);
                     m_omronServer.Start();
                     break;
 
                 case Protocol.ModbusTcp:
                 case Protocol.ModbusUdp:
-                    ModbusServer = new ModbusSimulatorServer(serverPort, selectedProtocol == Protocol.ModbusUdp);
+                    ModbusServer = new ModbusSimulatorServer(serverPort, selectedProtocol == Protocol.ModbusUdp, maxBitData, maxWordData);
                     break;
 
                 default:

--- a/PLCSimulator/Profile.cs
+++ b/PLCSimulator/Profile.cs
@@ -9,6 +9,8 @@ namespace PLCSimulator
         public Protocol Protocol = Protocol.MewtocolUdp;
         public int Port;
         public string PortName;
+        public int MaxBitData = 1600;
+        public int MaxWordData = 50000;
 
         public List<string> FavoriteAddress = new List<string>();
         public List<Description> DescriptionList = new List<Description>();

--- a/PLCSimulator/ProfileDlg.Designer.cs
+++ b/PLCSimulator/ProfileDlg.Designer.cs
@@ -36,27 +36,33 @@
             this.label_Protocol = new System.Windows.Forms.Label();
             this.label_Profile = new System.Windows.Forms.Label();
             this.comboBox_Profile = new System.Windows.Forms.ComboBox();
+            this.textBox_MaxBitData = new System.Windows.Forms.TextBox();
+            this.label_MaxBitData = new System.Windows.Forms.Label();
+            this.textBox_MaxWordData = new System.Windows.Forms.TextBox();
+            this.label_MaxWordData = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // comboBox_Protocol
             // 
+            this.comboBox_Protocol.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.comboBox_Protocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox_Protocol.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comboBox_Protocol.FormattingEnabled = true;
-            this.comboBox_Protocol.Location = new System.Drawing.Point(12, 136);
+            this.comboBox_Protocol.Location = new System.Drawing.Point(12, 175);
             this.comboBox_Protocol.Name = "comboBox_Protocol";
-            this.comboBox_Protocol.Size = new System.Drawing.Size(154, 26);
+            this.comboBox_Protocol.Size = new System.Drawing.Size(204, 26);
             this.comboBox_Protocol.TabIndex = 0;
             // 
             // button_Start
             // 
+            this.button_Start.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.button_Start.BackColor = System.Drawing.SystemColors.ButtonShadow;
             this.button_Start.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Start.Font = new System.Drawing.Font("Verdana", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Start.ForeColor = System.Drawing.Color.White;
-            this.button_Start.Location = new System.Drawing.Point(12, 230);
+            this.button_Start.Location = new System.Drawing.Point(12, 258);
             this.button_Start.Name = "button_Start";
-            this.button_Start.Size = new System.Drawing.Size(69, 41);
+            this.button_Start.Size = new System.Drawing.Size(94, 41);
             this.button_Start.TabIndex = 6;
             this.button_Start.Text = "Start";
             this.button_Start.UseVisualStyleBackColor = false;
@@ -64,13 +70,14 @@
             // 
             // button_Cancel
             // 
+            this.button_Cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.button_Cancel.BackColor = System.Drawing.SystemColors.ButtonShadow;
             this.button_Cancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.button_Cancel.Font = new System.Drawing.Font("Verdana", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.button_Cancel.ForeColor = System.Drawing.Color.White;
-            this.button_Cancel.Location = new System.Drawing.Point(97, 230);
+            this.button_Cancel.Location = new System.Drawing.Point(122, 258);
             this.button_Cancel.Name = "button_Cancel";
-            this.button_Cancel.Size = new System.Drawing.Size(69, 41);
+            this.button_Cancel.Size = new System.Drawing.Size(94, 41);
             this.button_Cancel.TabIndex = 7;
             this.button_Cancel.Text = "Cancel";
             this.button_Cancel.UseVisualStyleBackColor = false;
@@ -78,11 +85,12 @@
             // 
             // label_Port
             // 
+            this.label_Port.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label_Port.AutoSize = true;
             this.label_Port.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.label_Port.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Port.ForeColor = System.Drawing.Color.White;
-            this.label_Port.Location = new System.Drawing.Point(12, 165);
+            this.label_Port.Location = new System.Drawing.Point(12, 204);
             this.label_Port.Name = "label_Port";
             this.label_Port.Size = new System.Drawing.Size(46, 18);
             this.label_Port.TabIndex = 8;
@@ -90,20 +98,22 @@
             // 
             // textBox_Port
             // 
+            this.textBox_Port.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.textBox_Port.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_Port.Location = new System.Drawing.Point(12, 186);
+            this.textBox_Port.Location = new System.Drawing.Point(12, 225);
             this.textBox_Port.Name = "textBox_Port";
-            this.textBox_Port.Size = new System.Drawing.Size(154, 27);
+            this.textBox_Port.Size = new System.Drawing.Size(204, 27);
             this.textBox_Port.TabIndex = 9;
             this.textBox_Port.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox_Port_KeyDown);
             // 
             // label_Protocol
             // 
+            this.label_Protocol.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label_Protocol.AutoSize = true;
             this.label_Protocol.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.label_Protocol.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label_Protocol.ForeColor = System.Drawing.Color.White;
-            this.label_Protocol.Location = new System.Drawing.Point(12, 115);
+            this.label_Protocol.Location = new System.Drawing.Point(12, 154);
             this.label_Protocol.Name = "label_Protocol";
             this.label_Protocol.Size = new System.Drawing.Size(81, 18);
             this.label_Protocol.TabIndex = 10;
@@ -127,17 +137,61 @@
             this.comboBox_Profile.FormattingEnabled = true;
             this.comboBox_Profile.Location = new System.Drawing.Point(12, 30);
             this.comboBox_Profile.Name = "comboBox_Profile";
-            this.comboBox_Profile.Size = new System.Drawing.Size(154, 26);
+            this.comboBox_Profile.Size = new System.Drawing.Size(204, 26);
             this.comboBox_Profile.TabIndex = 11;
             this.comboBox_Profile.SelectedIndexChanged += new System.EventHandler(this.comboBox_Profile_SelectedIndexChanged);
+            // 
+            // textBox_MaxBitData
+            // 
+            this.textBox_MaxBitData.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textBox_MaxBitData.Location = new System.Drawing.Point(128, 62);
+            this.textBox_MaxBitData.Name = "textBox_MaxBitData";
+            this.textBox_MaxBitData.Size = new System.Drawing.Size(88, 27);
+            this.textBox_MaxBitData.TabIndex = 14;
+            // 
+            // label_MaxBitData
+            // 
+            this.label_MaxBitData.AutoSize = true;
+            this.label_MaxBitData.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.label_MaxBitData.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_MaxBitData.ForeColor = System.Drawing.Color.White;
+            this.label_MaxBitData.Location = new System.Drawing.Point(12, 65);
+            this.label_MaxBitData.Name = "label_MaxBitData";
+            this.label_MaxBitData.Size = new System.Drawing.Size(68, 18);
+            this.label_MaxBitData.TabIndex = 13;
+            this.label_MaxBitData.Text = "MaxBit";
+            // 
+            // textBox_MaxWordData
+            // 
+            this.textBox_MaxWordData.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.textBox_MaxWordData.Location = new System.Drawing.Point(128, 95);
+            this.textBox_MaxWordData.Name = "textBox_MaxWordData";
+            this.textBox_MaxWordData.Size = new System.Drawing.Size(88, 27);
+            this.textBox_MaxWordData.TabIndex = 16;
+            // 
+            // label_MaxWordData
+            // 
+            this.label_MaxWordData.AutoSize = true;
+            this.label_MaxWordData.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.label_MaxWordData.Font = new System.Drawing.Font("Verdana", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_MaxWordData.ForeColor = System.Drawing.Color.White;
+            this.label_MaxWordData.Location = new System.Drawing.Point(12, 98);
+            this.label_MaxWordData.Name = "label_MaxWordData";
+            this.label_MaxWordData.Size = new System.Drawing.Size(93, 18);
+            this.label_MaxWordData.TabIndex = 15;
+            this.label_MaxWordData.Text = "MaxWord";
             // 
             // ProfileDlg
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.ClientSize = new System.Drawing.Size(178, 283);
+            this.ClientSize = new System.Drawing.Size(228, 311);
             this.ControlBox = false;
+            this.Controls.Add(this.textBox_MaxWordData);
+            this.Controls.Add(this.label_MaxWordData);
+            this.Controls.Add(this.textBox_MaxBitData);
+            this.Controls.Add(this.label_MaxBitData);
             this.Controls.Add(this.label_Profile);
             this.Controls.Add(this.comboBox_Profile);
             this.Controls.Add(this.label_Protocol);
@@ -166,5 +220,9 @@
         private System.Windows.Forms.Label label_Protocol;
         private System.Windows.Forms.Label label_Profile;
         private System.Windows.Forms.ComboBox comboBox_Profile;
+        private System.Windows.Forms.TextBox textBox_MaxBitData;
+        private System.Windows.Forms.Label label_MaxBitData;
+        private System.Windows.Forms.TextBox textBox_MaxWordData;
+        private System.Windows.Forms.Label label_MaxWordData;
     }
 }

--- a/PLCSimulator/ProfileDlg.cs
+++ b/PLCSimulator/ProfileDlg.cs
@@ -32,6 +32,8 @@ namespace PLCSimulator
                 textBox_Port.Text = ProfileRecipe.Instance.ProfileInfo.PortName;
             else
                 textBox_Port.Text = ProfileRecipe.Instance.ProfileInfo.Port.ToString();
+            textBox_MaxBitData.Text = ProfileRecipe.Instance.ProfileInfo.MaxBitData.ToString();
+            textBox_MaxWordData.Text = ProfileRecipe.Instance.ProfileInfo.MaxWordData.ToString();
         }
 
         private void button_Start_Click(object sender, EventArgs e)
@@ -62,6 +64,10 @@ namespace PLCSimulator
             if (int.TryParse(textBox_Port.Text, out int port))
                 ProfileRecipe.Instance.ProfileInfo.Port = port;
             ProfileRecipe.Instance.ProfileInfo.PortName = textBox_Port.Text;
+            if (int.TryParse(textBox_MaxBitData.Text, out var maxBitData) && maxBitData > 0)
+                ProfileRecipe.Instance.ProfileInfo.MaxBitData = maxBitData;
+            if (int.TryParse(textBox_MaxWordData.Text, out var maxWordData) && maxWordData > 0)
+                ProfileRecipe.Instance.ProfileInfo.MaxWordData = maxWordData;
             ProfileRecipe.Instance.Save();
 
             DialogResult = DialogResult.OK;

--- a/PLCSimulator/ServerProtocol/MewtocolServer.cs
+++ b/PLCSimulator/ServerProtocol/MewtocolServer.cs
@@ -13,7 +13,7 @@ namespace PLCSimulator
 
         private ServerComm m_comm;
 
-        public MewtocolServer(int port) : this()
+        public MewtocolServer(int port, int maxBitData, int maxWordData) : this(maxBitData, maxWordData)
         {
             m_comm = new ServerCommUdp(port);
             m_comm.SetETX(Encoding.ASCII.GetBytes(new char[] { (char)0x0D }));
@@ -21,7 +21,7 @@ namespace PLCSimulator
             m_comm.OnReceiveMessage += MessageHandler;
         }
 
-        public MewtocolServer(string portName) : this()
+        public MewtocolServer(string portName, int maxBitData, int maxWordData) : this(maxBitData, maxWordData)
         {
             m_comm = new ServerCommSerial(portName);
             m_comm.SetETX(Encoding.ASCII.GetBytes(new char[] { (char)0x0D }));
@@ -29,12 +29,12 @@ namespace PLCSimulator
             m_comm.OnReceiveMessage += MessageHandler;
         }
 
-        public MewtocolServer()
+        public MewtocolServer(int maxBitData, int maxWordData)
         {
-            DataManager.Instance.BitDataDict.Add(R, new DataManager.BitData(1600, true));
-            DataManager.Instance.BitDataDict.Add(X, new DataManager.BitData(1600, true));
-            DataManager.Instance.BitDataDict.Add(Y, new DataManager.BitData(1600, true));
-            DataManager.Instance.WordDataDict.Add(DT, new DataManager.WordData(50000));
+            DataManager.Instance.BitDataDict.Add(R, new DataManager.BitData(maxBitData, true));
+            DataManager.Instance.BitDataDict.Add(X, new DataManager.BitData(maxBitData, true));
+            DataManager.Instance.BitDataDict.Add(Y, new DataManager.BitData(maxBitData, true));
+            DataManager.Instance.WordDataDict.Add(DT, new DataManager.WordData(maxWordData));
         }
 
         public void Start()

--- a/PLCSimulator/ServerProtocol/ModbusSimulatorServer.cs
+++ b/PLCSimulator/ServerProtocol/ModbusSimulatorServer.cs
@@ -14,7 +14,7 @@ namespace PLCSimulator
 
         private ModbusServer m_server;
 
-        public ModbusSimulatorServer(int port, bool udpFlag)
+        public ModbusSimulatorServer(int port, bool udpFlag, int maxBitData, int maxWordData)
         {
             m_server = new ModbusServer()
             {
@@ -24,10 +24,10 @@ namespace PLCSimulator
             };
             m_server.Listen();
 
-            DataManager.Instance.BitDataDict.Add(COIL, new DataManager.BitData(10000));
-            DataManager.Instance.BitDataDict.Add(DISCRETE_INPUT, new DataManager.BitData(10000));
-            DataManager.Instance.WordDataDict.Add(INPUT_REGISTER, new DataManager.WordData(10000));
-            DataManager.Instance.WordDataDict.Add(HOLDING_REGISTER, new DataManager.WordData(10000));
+            DataManager.Instance.BitDataDict.Add(COIL, new DataManager.BitData(maxBitData));
+            DataManager.Instance.BitDataDict.Add(DISCRETE_INPUT, new DataManager.BitData(maxBitData));
+            DataManager.Instance.WordDataDict.Add(INPUT_REGISTER, new DataManager.WordData(maxWordData));
+            DataManager.Instance.WordDataDict.Add(HOLDING_REGISTER, new DataManager.WordData(maxWordData));
 
             Task.Run(() => SyncData());
         }

--- a/PLCSimulator/ServerProtocol/UpperLinkServer.cs
+++ b/PLCSimulator/ServerProtocol/UpperLinkServer.cs
@@ -10,7 +10,7 @@ namespace PLCSimulator
 
         private ServerComm m_comm;
 
-        public UpperLinkServer(int port)
+        public UpperLinkServer(int port, int maxBitData, int maxWordData)
         {
             m_comm = new ServerCommUdp(port);
             m_comm.SetSTX(Encoding.ASCII.GetBytes(new char[] { '@' }));
@@ -18,7 +18,7 @@ namespace PLCSimulator
             m_comm.OnError += ex => LogWriter.Instance.LogError(ex);
             m_comm.OnReceiveMessage += MessageHandler;
 
-            DataManager.Instance.WordDataDict.Add(DM, new DataManager.WordData(50000));
+            DataManager.Instance.WordDataDict.Add(DM, new DataManager.WordData(maxWordData));
         }
 
         public void Start()


### PR DESCRIPTION
기존에는 각 프로토콜 별로 제공하는 최대 데이터 수가 고정되어 있어 해당 주소 이상의 주소가 필요할 경우 사용할 수가 없었다. 따라서 사용자 설정에 따라 최대 데이터 수를 변경할 수 있는 기능을 추가했다.